### PR TITLE
Tiny correction

### DIFF
--- a/data/epidoc_xml/HECATAEUS.xml
+++ b/data/epidoc_xml/HECATAEUS.xml
@@ -1168,7 +1168,7 @@
 					<quote>
 					Κορώνεια, Βοιωτίς Ἑκ. Εὐρ. Ἀπὸ Κορώνου τοῦ Θερσάνδρου.
 					</quote>
-					<note type="translation">Coronea, urbs Boeoliae, Hec.; a Corouo Thersandri filio.</note>
+					<note type="translation">Coronea, urbs Boeoliae, Hec.; a Corono Thersandri filio.</note>
 					<note type="commentary"></note>
 				</ref>
 			</cit>


### PR DESCRIPTION
In code line 1171 Corouo corrected to Corono. Presumably an OCR mistake. I have checked against the print edition.